### PR TITLE
bioc-devel in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: r
-r: bioc-release
+r: bioc-devel
 
 cache: packages
 


### PR DESCRIPTION
This package require R 3.5 and the devel version of BioConductor to be build.
